### PR TITLE
I've added Client_Id as a required field 

### DIFF
--- a/classes/TwitchAPI.php
+++ b/classes/TwitchAPI.php
@@ -38,11 +38,11 @@ class TwitchAPI
      * @param int $offset
      * @return string
      */
-    public function getTopList($type, $limit = 10, $offset = 0)
+    public function getTopList($type, $limit = 10, $offset = 0, $client_id)
     {
         $this->setListTypeSettings($type);
 
-        $json = $this->apiRequest($this->typeUrl."?limit=".$limit."&offset=".$offset);
+        $json = $this->apiRequest($this->typeUrl."?limit=".$limit."&offset=".$offset."&client_id=".$client_id);
         $object = json_decode($json, true);
 
         return $object[$this->typePrefix];
@@ -70,7 +70,7 @@ class TwitchAPI
     {
         switch ($type) {
             case 'games':
-                $this->typeUrl = '/games/top';
+                $this->typeUrl = "/games/top";
                 $this->typePrefix = "top";
                 break;
             case 'streams':

--- a/components/Check.php
+++ b/components/Check.php
@@ -17,7 +17,7 @@ class Check extends ComponentBase
     {
         return [
             'name'        => 'digitalronin.twitch::lang.check.name',
-            'description' => 'digitalronin.twitch::lang.check.description'
+            'description' => 'digitalronin.twitch::lang.check.description',
         ];
     }
 
@@ -30,6 +30,12 @@ class Check extends ComponentBase
             'channel' => [
                 'title'       => 'digitalronin.twitch::lang.settings.channel_name',
                 'description' => 'digitalronin.twitch::lang.settings.channel_description',
+                'type'        => 'string',
+                'required'    => true
+            ],
+            'client_id' => [
+                'title'       => 'digitalronin.twitch::lang.settings.channel_client_id',
+                'description' => 'digitalronin.twitch::lang.settings.channel_client_description',
                 'type'        => 'string',
                 'required'    => true
             ]
@@ -52,6 +58,6 @@ class Check extends ComponentBase
     public function getChannelStatus()
     {
         $twitch = new TwitchAPI();
-        return $twitch->isChannelLive($this->property('channel'));
+        return $twitch->isChannelLive($this->property('channel')."?client_id=".$this->property('client_id'));
     }
 }

--- a/components/Feed.php
+++ b/components/Feed.php
@@ -56,6 +56,12 @@ class Feed extends ComponentBase
                 'type'         => 'string',
                 'default'      => 'No posts found',
                 'showExternalParam' => false
+            ],
+                'client_id' => [
+                'title'       => 'digitalronin.twitch::lang.settings.channel_client_id',
+                'description' => 'digitalronin.twitch::lang.settings.channel_client_description',
+                'type'        => 'string',
+                'required'    => true
             ]
         ];
     }
@@ -74,7 +80,7 @@ class Feed extends ComponentBase
 
     protected function listPosts()
     {
-      $requestUrl = "/feed/".$this->property('channel')."/posts";
+      $requestUrl = "/feed/".$this->property('channel')."/posts"."?client_id=".$this->property('client_id');
       $twitch = new TwitchAPI();
 
       return json_decode($twitch->apiRequest($requestUrl), true)["posts"];

--- a/components/Stream.php
+++ b/components/Stream.php
@@ -64,6 +64,12 @@ class Stream extends  ComponentBase
                 'description' => 'digitalronin.twitch::lang.settings.chat_width_description',
                 'type'        => 'string',
                 'default'     => '300'
+            ],
+            'client_id' => [
+                'title'       => 'digitalronin.twitch::lang.settings.channel_client_id',
+                'description' => 'digitalronin.twitch::lang.settings.channel_client_description',
+                'type'        => 'string',
+                'required'    => true
             ]
         ];
     }

--- a/components/Toplist.php
+++ b/components/Toplist.php
@@ -48,6 +48,18 @@ class Toplist extends ComponentBase
                 'description' => 'digitalronin.twitch::lang.settings.limit_description',
                 'type'        => 'string',
                 'default'     => '10'
+            ],
+            'offset' => [
+                'title'       => 'digitalronin.twitch::lang.settings.offset_title',
+                'description' => 'digitalronin.twitch::lang.settings.offset_description',
+                'type'        => 'string',
+                'default'     => '0'
+            ],
+                'client_id' => [
+                'title'       => 'digitalronin.twitch::lang.settings.channel_client_id',
+                'description' => 'digitalronin.twitch::lang.settings.channel_client_description',
+                'type'        => 'string',
+                'required'    => true
             ]
         ];
     }
@@ -73,7 +85,7 @@ class Toplist extends ComponentBase
     public function getTwitchItems()
     {
         $twitch = new TwitchAPI();
-        return $twitch->getTopList( $this->toplistType, $this->totalItems );
+        return $twitch->getTopList( $this->toplistType, $this->totalItems, $this->property('offset'), $this->property('client_id'));
     }
 
     /**

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -8,6 +8,8 @@ return [
     'settings' => [
         'channel_name' => 'Channel Name',
         'channel_description' => 'Name of the twitch channel.',
+        'channel_client_id' => 'Client ID',
+        'channel_client_description' => 'Enter the Client ID of the Twitch Channel you wish to connect to',
         'twitch_id_title' => 'Twitch ID',
         'twitch_id_description' => 'Channel name for live streams or video id for past broadcast.',
         'width_name' => 'Stream Width',
@@ -18,6 +20,8 @@ return [
         'volume_description' => 'Default Volume of the embed Stream/Video.',
         'limit_title' => 'Limit',
         'limit_description' => 'Limit of Items to show. Default: 10',
+        'offset_title' => 'Offset',
+        'offset_description' => 'Offset the items to show. Default: 0',
         'posts_no_posts' => 'Show Twitch Feed Posts.',
         'posts_no_posts_description' => 'Show Twitch Feed Posts.',
         'chat_name' => 'Chat',
@@ -26,21 +30,24 @@ return [
         'chat_width_description' => 'Width of the Chat'
     ],
     'check' => [
-        'name' => 'Twitch Online Check',
+        'name' => 'Twitch Online Checker',
         'description' => 'Shows if a Channel is online.'
     ],
     'feed' => [
         'name' => 'Twitch Feed',
+        'client_id' => 'Client ID',
         'description' => 'Show Twitch Feed Posts.',
         'disabled' => 'This Channel Feed is disabled.'
     ],
     'toplist' => [
         'name' => 'Twitch Toplist',
+        'client_id' => 'Client ID',
         'description' => 'Outputs a Twitch Toplist.',
         'type_title' => 'Toplist Type'
     ],
     'stream' => [
         'name' => 'Twitch Stream',
+        'client_id' => 'Client ID',
         'description' => 'Embedding Twitch Live Streams & Videos',
         'type_title' => 'Type',
         'type_description' => 'Stream for live streams or Video for past broadcasts',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -30,7 +30,7 @@ return [
         'chat_width_description' => 'Width of the Chat'
     ],
     'check' => [
-        'name' => 'Twitch Online Checker',
+        'name' => 'Twitch Online Check',
         'description' => 'Shows if a Channel is online.'
     ],
     'feed' => [


### PR DESCRIPTION
Client_Id is now required for each and every API call per Twitch - so I added that field to all appropriate spots for Toplist, Check and Feed.

I also added Offset as an option for Toplist and it's now fully integrated.

Now the user simply enters their client_id in the appropriate spot and the plugin works as intended.